### PR TITLE
Support to Node.js ver4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "7"
+  - stable
   - "6"
+  - "4"

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const StyleStats = require('stylestats');
 const type = 'stylestats';
 const plugin = 'postcss-stylestats';
 
-module.exports = postcss.plugin(plugin, (opts = {}) => {
+module.exports = postcss.plugin(plugin, (opts) => {
+    opts = opts || {};
+
     return (root, result) => {
         const styleStats = new StyleStats(root.source.input.css, opts);
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "stylestats"
   ],
   "engines": {
-    "node": ">=6.x"
+    "node": ">=0.12"
   },
   "author": "kubosho <ta2@o2p.jp>",
   "license": "MIT",


### PR DESCRIPTION
## Why

PostCSS is support Node.js ver 4.x. This package follow it.

## Summary

- Check Node.js ver 4.x in Travis CI.
- Doesn't use optional parameter.